### PR TITLE
Add ability to define custom classNames via props.

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -2,6 +2,7 @@ const React = require('react');
 const Tag = require('./Tag');
 const Input = require('./Input');
 const Suggestions = require('./Suggestions');
+const merge = require('lodash/fp/merge');
 
 const Keys = {
     ENTER: 13,
@@ -10,6 +11,17 @@ const Keys = {
     UP_ARROW: 38,
     DOWN_ARROW: 40,
     ESCAPE: 27
+};
+
+const DefaultClassNames = {
+    tags: 'ReactTags',
+    tagInput: 'ReactTags__tagInput',
+    selected: 'ReactTags__selected',
+    tag: 'ReactTags__tag',
+    tagName: 'ReactTags__tagName',
+    suggestions: 'ReactTags__suggestions',
+    isActive: 'is-active',
+    isDisabled: 'is-disabled'
 };
 
 module.exports = React.createClass({
@@ -25,7 +37,8 @@ module.exports = React.createClass({
         handleAddition: React.PropTypes.func.isRequired,
         handleInputChange: React.PropTypes.func,
         minQueryLength: React.PropTypes.number,
-        maxSuggestionsLength: React.PropTypes.number
+        maxSuggestionsLength: React.PropTypes.number,
+        classNames: React.PropTypes.object
     },
 
     getDefaultProps() {
@@ -49,6 +62,12 @@ module.exports = React.createClass({
         };
     },
 
+    componentWillMount() {
+        this.setState({
+            classNames: merge(DefaultClassNames, this.props.classNames)
+        });
+    },
+
     componentDidMount() {
         if (this.props.autofocus) {
             this.refs.input.input.focus();
@@ -62,7 +81,8 @@ module.exports = React.createClass({
 
     componentWillReceiveProps(newProps) {
         this.setState({
-            suggestions: this.filteredSuggestions(this.state.query, newProps.suggestions).slice(0, this.props.maxSuggestionsLength)
+            suggestions: this.filteredSuggestions(this.state.query, newProps.suggestions).slice(0, this.props.maxSuggestionsLength),
+            classNames: merge(DefaultClassNames, newProps.classNames)
         });
     },
 
@@ -175,21 +195,22 @@ module.exports = React.createClass({
                     key={i}
                     tag={tag}
                     onDelete={this.handleDelete.bind(null, i)}
-                    removeComponent={this.props.removeComponent} />
+                    removeComponent={this.props.removeComponent}
+                    classNames={this.state.classNames} />
             );
         });
 
         const listboxId = 'ReactTags-listbox';
         const selectedId = `${listboxId}-${selectedIndex}`;
-        const { query, selectedIndex, suggestions } = this.state;
+        const { query, selectedIndex, suggestions, classNames } = this.state;
         const { placeholder, minQueryLength, autoresize } = this.props;
 
         return (
-            <div className='ReactTags' onClick={this.handleClick}>
-                <div className='ReactTags__selected' aria-live='polite' aria-relevant='additions removals'>
+            <div className={classNames.tags} onClick={this.handleClick}>
+                <div className={classNames.selected} aria-live='polite' aria-relevant='additions removals'>
                     {tagItems}
                 </div>
-                <div className='ReactTags__tagInput'>
+                <div className={classNames.tagInput}>
                     <Input
                         ref='input'
                         value={query}
@@ -202,14 +223,16 @@ module.exports = React.createClass({
                         aria-activedescendant={selectedIndex > -1 ? selectedId : null}
                         aria-expanded={selectedIndex > -1}
                         onChange={this.handleChange}
-                        onKeyDown={this.handleKeyDown} />
+                        onKeyDown={this.handleKeyDown}
+                        classNames={classNames} />
                     <Suggestions
                         listboxId={listboxId}
                         query={query}
                         selectedIndex={selectedIndex}
                         suggestions={suggestions}
                         handleClick={this.handleSuggestionClick}
-                        minQueryLength={minQueryLength} />
+                        minQueryLength={minQueryLength}
+                        classNames={classNames} />
                 </div>
             </div>
         );

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -2,7 +2,6 @@ const React = require('react');
 const Tag = require('./Tag');
 const Input = require('./Input');
 const Suggestions = require('./Suggestions');
-const merge = require('lodash/fp/merge');
 
 const Keys = {
     ENTER: 13,
@@ -64,7 +63,7 @@ module.exports = React.createClass({
 
     componentWillMount() {
         this.setState({
-            classNames: merge(DefaultClassNames, this.props.classNames)
+            classNames: Object.assign({}, DefaultClassNames, this.props.classNames)
         });
     },
 
@@ -82,7 +81,7 @@ module.exports = React.createClass({
     componentWillReceiveProps(newProps) {
         this.setState({
             suggestions: this.filteredSuggestions(this.state.query, newProps.suggestions).slice(0, this.props.maxSuggestionsLength),
-            classNames: merge(DefaultClassNames, newProps.classNames)
+            classNames: Object.assign({}, DefaultClassNames, newProps.classNames)
         });
     },
 

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -7,7 +7,8 @@ module.exports = React.createClass({
         selectedIndex: React.PropTypes.number.isRequired,
         suggestions: React.PropTypes.array.isRequired,
         handleClick: React.PropTypes.func.isRequired,
-        minQueryLength: React.PropTypes.number
+        minQueryLength: React.PropTypes.number,
+        classNames: React.PropTypes.object
     },
 
     markIt(input, query) {
@@ -24,8 +25,8 @@ module.exports = React.createClass({
             const key = `${this.props.listboxId}-${i}`;
 
             const classNames = [
-                this.props.selectedIndex === i ? 'is-active' : '',
-                item.disabled ? 'is-disabled' : ''
+                this.props.selectedIndex === i ? this.props.classNames.isActive : '',
+                item.disabled ? this.props.classNames.isDisabled : ''
             ];
 
             return (
@@ -42,11 +43,11 @@ module.exports = React.createClass({
         });
 
         if (suggestions.length === 0 || this.props.query.length < this.props.minQueryLength) {
-            return <div className='ReactTags__suggestions'></div>;
+            return <div className={this.props.classNames.suggestions}></div>;
         }
 
         return (
-            <div className='ReactTags__suggestions'>
+            <div className={this.props.classNames.suggestions}>
                 <ul role='listbox' id={this.props.listboxId}>{suggestions}</ul>
             </div>
         );

--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -4,13 +4,14 @@ module.exports = React.createClass({
 
     propTypes: {
         onDelete: React.PropTypes.func.isRequired,
-        tag: React.PropTypes.object.isRequired
+        tag: React.PropTypes.object.isRequired,
+        classNames: React.PropTypes.object
     },
 
     render(){
         return (
-            <button type='button' className='ReactTags__tag' title='Click to remove tag' onClick={this.props.onDelete}>
-                <span className='ReactTags__tagName'>{this.props.tag.name}</span>
+            <button type='button' className={this.props.classNames.tag} title='Click to remove tag' onClick={this.props.onDelete}>
+                <span className={this.props.classNames.tagName}>{this.props.tag.name}</span>
             </button>
         );
     }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "react-dom": "^0.14.0",
     "webpack": "^1.9.4",
     "webpack-dev-server": "^1.8.2"
+  },
+  "dependencies": {
+    "lodash": "^4.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "react-dom": "^0.14.0",
     "webpack": "^1.9.4",
     "webpack-dev-server": "^1.8.2"
-  },
-  "dependencies": {
-    "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
Hey,
i needed the functionality to use custom classNames, as provided in [prakhar1989/react-tags](https://github.com/prakhar1989/react-tags).

But since i think your code is much cleaner, i decided to add this feature to this fork.

What do you think?
Simon