### PR TITLE
Allow adding of newly created tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ React.render(<App />, document.getElementById('app'));
 - [`handleAddition`](#handleAdditionOption)
 - [`handleDelete`](#handleDeleteOption)
 - [`handleInputChange`](#handleInputChange)
+- [`allowNew`](#allowNew)
 
 <a name="tagsOption"></a>
 #### tags (optional)
@@ -172,6 +173,20 @@ function(input) {
         });
     }
 }
+```
+
+<a name="allowNew"></a>
+#### allowNew (optional)
+
+Allows users to add new (not suggested) tags. Default: `false`.
+
+To enable it, just add `allowNew` as a component property:
+
+```js
+<ReactTags
+    handleDelete={this.handleDelete}
+    handleAddition={this.handleAddition}
+    allowNew />
 ```
 
 ### Styling

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -37,7 +37,8 @@ module.exports = React.createClass({
         handleInputChange: React.PropTypes.func,
         minQueryLength: React.PropTypes.number,
         maxSuggestionsLength: React.PropTypes.number,
-        classNames: React.PropTypes.object
+        classNames: React.PropTypes.object,
+        allowNew: React.PropTypes.bool
     },
 
     getDefaultProps() {
@@ -49,7 +50,8 @@ module.exports = React.createClass({
             autofocus: true,
             autoresize: true,
             minQueryLength: 2,
-            maxSuggestionsLength: 6
+            maxSuggestionsLength: 6,
+            allowNew: false
         };
     },
 
@@ -121,11 +123,21 @@ module.exports = React.createClass({
         // end up with a terminating character typed in.
         if (this.props.delimiters.indexOf(e.keyCode) !== -1) {
             if (e.keyCode !== Keys.TAB || query) {
-              e.preventDefault();
+                e.preventDefault();
             }
 
-            if (this.state.selectedIndex > -1) {
-                this.addTag(this.state.suggestions[this.state.selectedIndex]);
+            if (query && query.length >= this.props.minQueryLength) {
+                // Check if the user typed in an existing suggestion.
+                const match = suggestions.findIndex(suggestion => {
+                    return suggestion.name.search(new RegExp(query, 'i')) === 0;
+                });
+                const index = selectedIndex === -1 ? match : selectedIndex;
+
+                if (index > -1) {
+                    this.addTag(suggestions[index]);
+                } else if (this.props.allowNew) {
+                    this.addTag({ name: query });
+                }
             }
         }
 
@@ -139,13 +151,13 @@ module.exports = React.createClass({
             e.preventDefault();
 
             // if last item, cycle to the bottom
-            if (this.state.selectedIndex <= 0) {
+            if (selectedIndex <= 0) {
                 this.setState({
-                    selectedIndex: this.state.suggestions.length - 1
+                    selectedIndex: suggestions.length - 1
                 });
             } else {
                 this.setState({
-                    selectedIndex: this.state.selectedIndex - 1
+                    selectedIndex: selectedIndex - 1
                 });
             }
         }
@@ -155,7 +167,7 @@ module.exports = React.createClass({
             e.preventDefault();
 
             this.setState({
-                selectedIndex: (this.state.selectedIndex + 1) % suggestions.length
+                selectedIndex: (selectedIndex + 1) % suggestions.length
             });
         }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "contributors": [
     "Prakhar Srivastav",
-    "Matt Hinchliffe"
+    "Matt Hinchliffe",
+    "Simon Hötten"
   ],
   "license": "MIT",
   "repository": "https://github.com/i-like-robots/react-tags",


### PR DESCRIPTION
Hey there,
it's me again ;)

This introduces a new boolean property, called `allowNew`. The default is `false`, which results in the same behaviour as before. Only change is that users can type in the full tag name of existing tags, in order to add them (no need to manually select them, if you don't want to).

If `allowNew` is set to `true`, users can just type in non existing tags and add them with a delimiter key. In that case, a new tag object with just the name attribute is created. I think it's best to let the user handle all other attributes in the `handleAddition()` method.

Cheers..