### PR TITLE
Upgrade to react ^15.2.1

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -47,13 +47,15 @@ module.exports = React.createClass({
     },
 
     render() {
-        const { value, placeholder } = this.props;
-        const style = this.props.autoresize ? { width: this.state.inputWidth } : null;
+        const { autoresize, ...other } = this.props;
+        const style = autoresize ? { width: this.state.inputWidth } : null;
 
         return (
             <div>
-                <input ref={(c) => this.input = c} {...this.props} style={style} />
-                <div ref={(c) => this.sizer = c} style={sizerStyles}>{value || placeholder}</div>
+                <input ref={(c) => this.input = c} {...other} style={style} />
+                <div ref={(c) => this.sizer = c} style={sizerStyles}>
+                    {this.props.value || this.props.placeholder}
+                </div>
             </div>
         );
     }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "license": "MIT",
   "repository": "https://github.com/i-like-robots/react-tags",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.2.1",
+    "react-dom": "^15.2.1"
   },
   "devDependencies": {
     "babel": "^5.3.3",
     "babel-loader": "^5.1.2",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.2.1",
+    "react-dom": "^15.2.1",
     "webpack": "^1.9.4",
     "webpack-dev-server": "^1.8.2"
   }


### PR DESCRIPTION
This upgrades react to ^15.2.1 and solves the `Unknown prop 'autoresize' on <input> tag` warning, triggered in this version. Solves #13 

I thought about different approaches to get rid of the autoresize prop, but all other options than to do it directly in the render method (e.g. only merging the changed properties into a properties object, stored in the component state) seamed too complicated and not worth the effort, because the comparison would take longer than to just to it on every render.

What do you think?

Btw: To be able to see this warning you have to set` 'process.env': { 'NODE_ENV': '"development"' }` in the webpack config.