### PR TITLE
Add 'is-focused' class to main div, when the Input component is focused.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ Override the default class names. Defaults:
     tagName: 'ReactTags__tagName',
     suggestions: 'ReactTags__suggestions',
     isActive: 'is-active',
-    isDisabled: 'is-disabled'
+    isDisabled: 'is-disabled',
+    isFocused: 'is-focused'
 }
 ```
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -20,7 +20,8 @@ const DefaultClassNames = {
     tagName: 'ReactTags__tagName',
     suggestions: 'ReactTags__suggestions',
     isActive: 'is-active',
-    isDisabled: 'is-disabled'
+    isDisabled: 'is-disabled',
+    isFocused: 'is-focused'
 };
 
 module.exports = React.createClass({
@@ -183,6 +184,10 @@ module.exports = React.createClass({
         }
     },
 
+    handleFocus() {
+        this.setState({ focused: !this.state.focused });
+    },
+
     addTag(tag) {
         if (tag.disabled) {
             return;
@@ -212,13 +217,22 @@ module.exports = React.createClass({
             );
         });
 
-        const { query, selectedIndex, suggestions, classNames } = this.state;
+        const { query, selectedIndex, suggestions, classNames, focused } = this.state;
         const { placeholder, minQueryLength, autoresize } = this.props;
         const listboxId = 'ReactTags-listbox';
         const selectedId = `${listboxId}-${selectedIndex}`;
 
+        const rootClasses = [
+            classNames.root,
+            focused ? classNames.isFocused : ''
+        ];
+
         return (
-            <div className={classNames.root} onClick={this.handleClick}>
+            <div
+                className={rootClasses.join(' ')}
+                onClick={this.handleClick}
+                onFocus={this.handleFocus}
+                onBlur={this.handleFocus} >
                 <div className={classNames.selected} aria-live='polite' aria-relevant='additions removals'>
                     {tagItems}
                 </div>


### PR DESCRIPTION
The app i'm working on requires styling based on whether input elements are focused or not and i think other users could benefit from this as well.
Since the css :focus selector does not apply to parent elements, this needs to be done in javascript.