### PR TITLE
Makes the tag rendering component configurable... keeps original default

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -136,9 +136,14 @@ class ReactTags extends React.Component {
 
   render () {
     const listboxId = 'ReactTags-listbox'
-
+    let TagComponent;
+    if (this.props.tagComponent) {
+      TagComponent = this.props.tagComponent;
+    } else {
+      TagComponent = Tag;
+    }
     const tags = this.props.tags.map((tag, i) => (
-      <Tag
+      <TagComponent
         key={i}
         tag={tag}
         classNames={this.state.classNames}

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -136,11 +136,11 @@ class ReactTags extends React.Component {
 
   render () {
     const listboxId = 'ReactTags-listbox'
-    let TagComponent;
+    let TagComponent
     if (this.props.tagComponent) {
-      TagComponent = this.props.tagComponent;
+      TagComponent = this.props.tagComponent
     } else {
-      TagComponent = Tag;
+      TagComponent = Tag
     }
     const tags = this.props.tags.map((tag, i) => (
       <TagComponent


### PR DESCRIPTION
Allows passing a custom component to ReactTags to perform the actual rendering of each tag:

``` jsx
class CustomTag extends React.Component {
  render() {
     return(<span>My tag: {this.props.tag.name}</span>)
  }
}

<ReactTags
  handleAddition={additionHandler}
  handleDelete={deleteHandler}
  tags={tags}
  tagComponent={CustomTag}
/>
```

If no tagComponent is passed, then it uses the existing renderer component as the default.
