### PR TITLE
Recalculate input width when input-related props are changed

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -19,6 +19,16 @@ const STYLE_PROPS = [
   'letterSpacing'
 ]
 
+/**
+ * Changing any of these props while `autoresize` is true will cause the input width to be
+ * recalculated
+ */
+const RESIZE_PROPS = [
+  'query',
+  'placeholder',
+  'classNames'
+]
+
 class Input extends React.Component {
   constructor (props) {
     super(props)
@@ -37,7 +47,9 @@ class Input extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    if (this.props.autoresize && prevProps.query !== this.props.query) {
+    if (prevProps.autoresize !== this.props.autoresize ||
+      (this.props.autoresize && RESIZE_PROPS.some((prop) => this.props[prop] !== prevProps[prop]))
+    ) {
       this.updateInputWidth()
     }
   }
@@ -57,7 +69,9 @@ class Input extends React.Component {
   }
 
   updateInputWidth () {
-    this.setState({ inputWidth: Math.ceil(this.sizer.scrollWidth) + 2 })
+    this.setState({
+      inputWidth: this.props.autoresize ? Math.ceil(this.sizer.scrollWidth) + 2 : null
+    })
   }
 
   render () {

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -19,16 +19,6 @@ const STYLE_PROPS = [
   'letterSpacing'
 ]
 
-/**
- * Changing any of these props while `autoresize` is true will cause the input width to be
- * recalculated
- */
-const RESIZE_PROPS = [
-  'query',
-  'placeholder',
-  'classNames'
-]
-
 class Input extends React.Component {
   constructor (props) {
     super(props)
@@ -47,11 +37,7 @@ class Input extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    if (prevProps.autoresize !== this.props.autoresize ||
-      (this.props.autoresize && RESIZE_PROPS.some((prop) => this.props[prop] !== prevProps[prop]))
-    ) {
-      this.updateInputWidth()
-    }
+    this.updateInputWidth()
   }
 
   componentWillReceiveProps (newProps) {
@@ -69,9 +55,11 @@ class Input extends React.Component {
   }
 
   updateInputWidth () {
-    this.setState({
-      inputWidth: this.props.autoresize ? Math.ceil(this.sizer.scrollWidth) + 2 : null
-    })
+    const inputWidth = this.props.autoresize && this.sizer.scrollWidth ? Math.ceil(this.sizer.scrollWidth) + 2 : null
+
+    if (inputWidth !== this.state.inputWidth) {
+      this.setState({ inputWidth })
+    }
   }
 
   render () {

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -377,4 +377,21 @@ describe('React Tags', () => {
       expect(window.getComputedStyle(input).width).toEqual('202px')
     })
   })
+
+  describe('without autoresize', () => {
+    beforeEach(() => {
+      createInstance({ autoresize: false })
+    })
+
+    it('does not assign a width to the input', () => {
+      const input = $('input')
+      const sizer = $('input + div')
+
+      sizer.scrollWidth = 200
+
+      type('hello world')
+
+      expect(input.style.width).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
This recalculates the input width when `autoresize` is true and the `query`, `placeholder`, or `classNames` prop changes. Previously it only recalculated on the `query` prop changing, but changing the placeholder text or the any of the input classes could also effect the calculated width. Additionally, this _unsets_ the width style if the `autoresize` property is changed from `true` to `false`.