### PR TITLE
iOS 7-8 Object.assign fix

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const React = require('react')
+const React = require('react')'
 const Tag = require('./Tag')
 const Input = require('./Input')
 const Suggestions = require('./Suggestions')
+const assign = require('object-assign')
 
 const KEYS = {
   ENTER: 13,
@@ -35,13 +36,13 @@ class ReactTags extends React.Component {
       focused: false,
       expandable: false,
       selectedIndex: -1,
-      classNames: Object.assign({}, CLASS_NAMES, this.props.classNames)
+      classNames: assign({}, CLASS_NAMES, this.props.classNames)
     }
   }
 
   componentWillReceiveProps (newProps) {
     this.setState({
-      classNames: Object.assign({}, CLASS_NAMES, newProps.classNames)
+      classNames: assign({}, CLASS_NAMES, newProps.classNames)
     })
   }
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const React = require('react')'
+const React = require('react')
 const Tag = require('./Tag')
 const Input = require('./Input')
 const Suggestions = require('./Suggestions')

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
+		"object-assign": "^4.1.1",
     "buble": "^0.12.5",
     "buble-loader": "^0.2.2",
     "coveralls": "^2.11.12",


### PR DESCRIPTION
I have bumped into this issue while working on a chat app.
Works just fine on `Android 4.3+` but, had issue with older iOS versions, since iOS 8 and iOS 9 don't have support for `Object.assign`