### PR TITLE
Fix keydown with empty query does not prevent default

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -61,7 +61,7 @@ class ReactTags extends React.Component {
 
     // when one of the terminating keys is pressed, add current query to the tags.
     if (this.props.delimiters.indexOf(e.keyCode) !== -1) {
-      query && e.preventDefault()
+      (query || selectedIndex > -1) && e.preventDefault()
 
       if (query.length >= this.props.minQueryLength) {
         // Check if the user typed in an existing suggestion.


### PR DESCRIPTION
With minQueryLength set to zero, when I select a tag from suggestion with a keyboard, without typing anything, my form is submitted, because handleKeyDown does not prevent default when the query is empty.

This PR solves that issue.