### PR TITLE
fixes issue #84, for pasting with delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Array of integers matching keyboard event `keyCode` values. When a corresponding
 
 #### delimiterChars (optional)
 
-Array of characters matching keyboard event `key` values. This is useful when needing to support a specific character irrespective of the keyboard layout. Note, that this list is separate from the one specified by the `delimiters` option, so you'll need to set the value there to `[]`, if you wish to disable those keys. Example usage: `delimiterChars={[',', ' ']}`. Default: `[]`
+Array of characters matching keyboard event `key` values. This is useful when needing to support a specific character irrespective of the keyboard layout. Note, that this list is separate from the one specified by the `delimiters` option, so you'll need to set the value there to `[]`, if you wish to disable those keys. Note, that specifying delimiters longer than one character is only supported for paste operations. Example usage: `delimiterChars={[',', ' ']}`. Default: `['\t', '\r\n', '\r', '\n']`
 
 #### minQueryLength (optional)
 

--- a/example/main.js
+++ b/example/main.js
@@ -37,9 +37,8 @@ class App extends React.Component {
           tags={this.state.tags}
           suggestions={this.state.suggestions}
           handleDelete={this.handleDelete.bind(this)}
-          handleAddition={this.handleAddition.bind(this)}
-          allowNew={true}
-          />
+          handleAddition={this.handleAddition.bind(this)}          
+        />
         <hr />
         <pre><code>{JSON.stringify(this.state.tags, null, 2)}</code></pre>
       </div>

--- a/example/main.js
+++ b/example/main.js
@@ -33,10 +33,13 @@ class App extends React.Component {
     return (
       <div>
         <Tags
+          delimiterChars={[',', ' ', '\t']}
           tags={this.state.tags}
           suggestions={this.state.suggestions}
           handleDelete={this.handleDelete.bind(this)}
-          handleAddition={this.handleAddition.bind(this)} />
+          handleAddition={this.handleAddition.bind(this)}
+          allowNew={true}
+          />
         <hr />
         <pre><code>{JSON.stringify(this.state.tags, null, 2)}</code></pre>
       </div>

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -63,7 +63,7 @@ class ReactTags extends React.Component {
     }
 
     const { delimiters, delimiterChars } = this.props
-    
+
     e.preventDefault()
 
     // get the text data from the clipboard
@@ -73,7 +73,7 @@ class ReactTags extends React.Component {
       // split the string based on the delimiterChars as a regex
       const tags = data.split(new RegExp(delimiterChars.join('|'), 'g'));
       for (let i=0; i < tags.length; i++) {
-        // the logic here is similar to handleKeyDown, but subtly different, 
+        // the logic here is similar to handleKeyDown, but subtly different,
         // due to the context of the operation
         if (tags[i].length > 0) {
           // look to see if the tag is already known
@@ -88,7 +88,7 @@ class ReactTags extends React.Component {
             this.addTag({ name: tags[i] })
           }
         }
-      }    
+      }
     }
   }
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -110,7 +110,7 @@ class ReactTags extends React.Component {
       if (query || selectedIndex > -1) {
         e.preventDefault()
       }
-      
+
       if (query.length >= this.props.minQueryLength) {
         // Check if the user typed in an existing suggestion.
         const match = this.suggestions.state.options.findIndex((suggestion) => {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -38,30 +38,16 @@ class ReactTags extends React.Component {
       selectedIndex: -1,
       classNames: Object.assign({}, CLASS_NAMES, this.props.classNames)
     }
-
-    this.checkDelimiterChars(props.delimiterChars)
-  }
-
-  /**
-   * Checks that each entry of delimiterChars is only a single
-   * character long.
-   *
-   * @param {Array} delimiterChars
-   */
-  checkDelimiterChars (delimiterChars) {
-    if (delimiterChars && delimiterChars.length > 0) {
-      delimiterChars.forEach((delimiterChar) => {
-        if (delimiterChar.length > 1) {
-          throw new Error(`DelimiterChar entries should be single characters, invalid: ${delimiterChar}`)
-        }
-      })
-    }
   }
 
   componentWillReceiveProps (newProps) {
     this.setState({
       classNames: Object.assign({}, CLASS_NAMES, newProps.classNames)
     })
+  }
+
+  escapeForRegExp (query) {
+    return query.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
   }
 
   handleChange (e) {
@@ -90,7 +76,7 @@ class ReactTags extends React.Component {
     if (data && delimiterChars.length > 0) {
       // split the string based on the delimiterChars as a regex, being sure
       // to escape chars, to prevent them being treated as special characters
-      const tags = data.split(new RegExp('[\\' + delimiterChars.join('\\') + ']'))
+      const tags = data.split(new RegExp('[' + this.escapeForRegExp(delimiterChars.join('')) + ']'))
       for (let i = 0; i < tags.length; i++) {
         // the logic here is similar to handleKeyDown, but subtly different,
         // due to the context of the operation
@@ -251,7 +237,7 @@ ReactTags.defaultProps = {
   autofocus: true,
   autoresize: true,
   delimiters: [KEYS.TAB, KEYS.ENTER],
-  delimiterChars: [],
+  delimiterChars: ['\t', '\r\n', '\r', '\n'],
   minQueryLength: 2,
   maxSuggestionsLength: 6,
   allowNew: false,

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -56,6 +56,42 @@ class ReactTags extends React.Component {
     this.setState({ query })
   }
 
+  handlePaste (e) {
+    // allow over-ride, if there is a need
+    if (this.props.onPaste) {
+      return this.props.onPaste(e);
+    }
+
+    const { delimiters, delimiterChars } = this.props
+    
+    e.preventDefault()
+
+    // get the text data from the clipboard
+    const data = e.clipboardData.getData('Text')
+
+    if (data && delimiterChars.length > 0) {
+      // split the string based on the delimiterChars as a regex
+      const tags = data.split(new RegExp(delimiterChars.join('|'), 'g'));
+      for (let i=0; i < tags.length; i++) {
+        // the logic here is similar to handleKeyDown, but subtly different, 
+        // due to the context of the operation
+        if (tags[i].length > 0) {
+          // look to see if the tag is already known
+          const matchIdx = this.suggestions.state.options.findIndex((suggestion) => {
+            return tags[i] === suggestion.name
+          })
+
+          // if already known add it, otherwise add it only if we allow new tags
+          if (matchIdx > -1) {
+            this.addTag(this.suggestions.state.options[matchIdx])
+          } else if (this.props.allowNew) {
+            this.addTag({ name: tags[i] })
+          }
+        }
+      }    
+    }
+  }
+
   handleKeyDown (e) {
     const { query, selectedIndex } = this.state
     const { delimiters, delimiterChars } = this.props
@@ -166,14 +202,16 @@ class ReactTags extends React.Component {
           onBlur={this.handleBlur.bind(this)}
           onFocus={this.handleFocus.bind(this)}
           onChange={this.handleChange.bind(this)}
-          onKeyDown={this.handleKeyDown.bind(this)}>
+          onKeyDown={this.handleKeyDown.bind(this)}
+          onPaste={this.handlePaste.bind(this)} >
           <Input {...this.state}
             ref={(c) => { this.input = c }}
             listboxId={listboxId}
             autofocus={this.props.autofocus}
             autoresize={this.props.autoresize}
             expandable={expandable}
-            placeholder={this.props.placeholder} />
+            placeholder={this.props.placeholder}
+            />
           <Suggestions {...this.state}
             ref={(c) => { this.suggestions = c }}
             listboxId={listboxId}

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -38,6 +38,24 @@ class ReactTags extends React.Component {
       selectedIndex: -1,
       classNames: Object.assign({}, CLASS_NAMES, this.props.classNames)
     }
+
+    this.checkDelimiterChars(props.delimiterChars)
+  }
+
+  /**
+   * Checks that each entry of delimiterChars is only a single
+   * character long.
+   *
+   * @param {Array} delimiterChars
+   */
+  checkDelimiterChars (delimiterChars) {
+    if (delimiterChars && delimiterChars.length > 0) {
+      delimiterChars.forEach((delimiterChar) => {
+        if (delimiterChar.length > 1) {
+          throw new Error(`DelimiterChar entries should be single characters, invalid: ${delimiterChar}`)
+        }
+      })
+    }
   }
 
   componentWillReceiveProps (newProps) {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -59,10 +59,10 @@ class ReactTags extends React.Component {
   handlePaste (e) {
     // allow over-ride, if there is a need
     if (this.props.onPaste) {
-      return this.props.onPaste(e);
+      return this.props.onPaste(e)
     }
 
-    const { delimiters, delimiterChars } = this.props
+    const { delimiterChars } = this.props
 
     e.preventDefault()
 
@@ -71,8 +71,8 @@ class ReactTags extends React.Component {
 
     if (data && delimiterChars.length > 0) {
       // split the string based on the delimiterChars as a regex
-      const tags = data.split(new RegExp(delimiterChars.join('|'), 'g'));
-      for (let i=0; i < tags.length; i++) {
+      const tags = data.split(new RegExp(delimiterChars.join('|'), 'g'))
+      for (let i = 0; i < tags.length; i++) {
         // the logic here is similar to handleKeyDown, but subtly different,
         // due to the context of the operation
         if (tags[i].length > 0) {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -58,8 +58,8 @@ class ReactTags extends React.Component {
 
   handlePaste (e) {
     // allow over-ride, if there is a need
-    if (this.props.onPaste) {
-      return this.props.onPaste(e)
+    if (this.props.handlePaste) {
+      return this.props.handlePaste(e)
     }
 
     const { delimiterChars } = this.props
@@ -70,20 +70,21 @@ class ReactTags extends React.Component {
     const data = e.clipboardData.getData('Text')
 
     if (data && delimiterChars.length > 0) {
-      // split the string based on the delimiterChars as a regex
-      const tags = data.split(new RegExp(delimiterChars.join('|'), 'g'))
+      // split the string based on the delimiterChars as a regex, being sure
+      // to escape chars, to prevent them being treated as special characters
+      const tags = data.split(new RegExp('[\\' + delimiterChars.join('\\') + ']'))
       for (let i = 0; i < tags.length; i++) {
         // the logic here is similar to handleKeyDown, but subtly different,
         // due to the context of the operation
         if (tags[i].length > 0) {
           // look to see if the tag is already known
-          const matchIdx = this.suggestions.state.options.findIndex((suggestion) => {
+          const matchIdx = this.props.suggestions.findIndex((suggestion) => {
             return tags[i] === suggestion.name
           })
 
           // if already known add it, otherwise add it only if we allow new tags
           if (matchIdx > -1) {
-            this.addTag(this.suggestions.state.options[matchIdx])
+            this.addTag(this.props.suggestions[matchIdx])
           } else if (this.props.allowNew) {
             this.addTag({ name: tags[i] })
           }
@@ -251,6 +252,7 @@ ReactTags.propTypes = {
   handleDelete: PropTypes.func.isRequired,
   handleAddition: PropTypes.func.isRequired,
   handleInputChange: PropTypes.func,
+  handlePaste: PropTypes.func,
   minQueryLength: PropTypes.number,
   maxSuggestionsLength: PropTypes.number,
   classNames: PropTypes.object,

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -94,6 +94,10 @@ class ReactTags extends React.Component {
           }
         }
       }
+    } else if (!delimiterChars || delimiterChars.length === 0) {
+      if (console) {
+        console.warn('no delimiterChars specified, so ignoring paste operation')
+      }
     }
   }
 
@@ -106,7 +110,7 @@ class ReactTags extends React.Component {
       if (query || selectedIndex > -1) {
         e.preventDefault()
       }
-
+      
       if (query.length >= this.props.minQueryLength) {
         // Check if the user typed in an existing suggestion.
         const match = this.suggestions.state.options.findIndex((suggestion) => {

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -64,6 +64,10 @@ function click (target) {
   TestUtils.Simulate.click(target)
 }
 
+function paste (target, eventData) {
+  TestUtils.Simulate.paste(target, eventData)
+}
+
 describe('React Tags', () => {
   afterEach(() => {
     teardownInstance()
@@ -370,6 +374,17 @@ describe('React Tags', () => {
       })
 
       expect($$('.custom-tag').length).toEqual(2)
+    })
+
+    it('can receive tags through paste, respecting delimiters', () => {
+      createInstance({ allowNew: true, delimiterChars: [',', ';'] })
+
+      paste($('input'), { clipboardData: {
+        types: ['text/plain', 'Text'],
+        getData: (type) => 'foo,bar;baz'
+      }})
+
+      sinon.assert.calledThrice(props.handleAddition)
     })
   })
 

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -410,6 +410,23 @@ describe('React Tags', () => {
       sinon.assert.callCount(props.handleAddition, 7)
     })
 
+    it('ignores paste operation, if no delimiterChars are specified', () => {
+      // The large range of delimiterChars in the test is to ensure
+      // they don't take on new meaning when used as part of a regex.
+      // Also ensure we accept multicharacter separators, in this scenario
+      createInstance({
+        allowNew: true,
+        delimiterChars: []
+      })
+
+      paste($('input'), { clipboardData: {
+        types: ['text/plain', 'Text'],
+        getData: (type) => 'foo\tbar\r\nbaz\rfam\nbam'
+      }})
+
+      sinon.assert.callCount(props.handleAddition, 0)
+    })
+
     it('can receive tags through paste, ignoring new tags', () => {
       createInstance({
         allowNew: false,

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -376,6 +376,14 @@ describe('React Tags', () => {
       expect($$('.custom-tag').length).toEqual(2)
     })
 
+    it('will throw an error if a delimiter is longer than one character', () => {
+      expect(() => createInstance({
+        allowNew: true,
+        delimiterChars: [',', ',X'],
+        suggestions: [{ id: 1, name: 'foo' }]
+      })).toThrow()
+    })
+
     it('can receive tags through paste, respecting delimiters', () => {
       // The large range of delimiterChars in the test is to ensure
       // they don't take on new meaning when used as part of a regex.

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -376,29 +376,38 @@ describe('React Tags', () => {
       expect($$('.custom-tag').length).toEqual(2)
     })
 
-    it('will throw an error if a delimiter is longer than one character', () => {
-      expect(() => createInstance({
-        allowNew: true,
-        delimiterChars: [',', ',X'],
-        suggestions: [{ id: 1, name: 'foo' }]
-      })).toThrow()
-    })
-
-    it('can receive tags through paste, respecting delimiters', () => {
+    it('can receive tags through paste, respecting default delimiter chars', () => {
       // The large range of delimiterChars in the test is to ensure
       // they don't take on new meaning when used as part of a regex.
+      // Also ensure we accept multicharacter separators, in this scenario
+      createInstance({
+        allowNew: true
+      })
+
+      paste($('input'), { clipboardData: {
+        types: ['text/plain', 'Text'],
+        getData: (type) => 'foo\tbar\r\nbaz\rfam\nbam'
+      }})
+
+      sinon.assert.callCount(props.handleAddition, 5)
+    })
+
+    it('can receive tags through paste, respecting delimiter chars', () => {
+      // The large range of delimiterChars in the test is to ensure
+      // they don't take on new meaning when used as part of a regex.
+      // Also ensure we accept multicharacter separators, in this scenario
       createInstance({
         allowNew: true,
-        delimiterChars: ['^', ',', ';', '.', '\\', '['],
+        delimiterChars: ['^', ',', ';', '.', '\\', '[', ']X'],
         suggestions: [{ id: 1, name: 'foo' }]
       })
 
       paste($('input'), { clipboardData: {
         types: ['text/plain', 'Text'],
-        getData: (type) => 'foo,bar;baz^fam\\bam[moo'
+        getData: (type) => 'foo,bar;baz^fam\\bam[moo]Xark'
       }})
 
-      sinon.assert.callCount(props.handleAddition, 6)
+      sinon.assert.callCount(props.handleAddition, 7)
     })
 
     it('can receive tags through paste, ignoring new tags', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,13 @@ module.exports = {
   output: {
     filename: 'example/bundle.js'
   },
+  devServer: {
+    disableHostCheck: true,
+    // listen server to be accessed from another host
+    // useful for mobile testing
+    host: "0.0.0.0",
+    port: process.env.PORT || 8080
+  }
   // resolve: {
   //   alias: {
   //     'react': 'preact-compat',


### PR DESCRIPTION
Changes to support pasting with delimiters, but currently missing a test case, since I am not sure how to write one that support the browser clipboard. I am a little new to Istanbul code coverage. Any suggestions would be appreciated.