### PR TITLE
Fix tag component link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ React.render(<App />, document.getElementById('app'))
 - [`handleDelete`](#handledelete-optional)
 - [`handleInputChange`](#handleinputchange-optional)
 - [`allowNew`](#allownew-optional)
-- [`tagComponent`](#tagc`omponent-optional)
+- [`tagComponent`](#tagcomponent-optional)
 
 #### tags (optional)
 


### PR DESCRIPTION
Removes the stray character from the readme which breaks the link to the `tagComponent` option