### PR TITLE
Add blur/focus listening for the parent

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -115,7 +115,7 @@ class ReactTags extends React.Component {
     this.setState({ focused: false, selectedIndex: -1 })
 
     if (this.props.onBlur) {
-      this.props.onBlur()
+      this.props.onBlur(this)
     }
   }
 
@@ -123,7 +123,7 @@ class ReactTags extends React.Component {
     this.setState({ focused: true })
 
     if (this.props.onFocus) {
-      this.props.onFocus()
+      this.props.onFocus(this)
     }
   }
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -124,7 +124,7 @@ class ReactTags extends React.Component {
 
     if (this.props.onFocus) {
       this.props.onFocus()
-    }    
+    }
   }
 
   addTag (tag) {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -113,10 +113,18 @@ class ReactTags extends React.Component {
 
   handleBlur () {
     this.setState({ focused: false, selectedIndex: -1 })
+
+    if (this.props.onBlur) {
+      this.props.onBlur()
+    }
   }
 
   handleFocus () {
     this.setState({ focused: true })
+
+    if (this.props.onFocus) {
+      this.props.onFocus()
+    }    
   }
 
   addTag (tag) {


### PR DESCRIPTION
This is a minimal amount of code that adds focus and blur triggers so that parent components can do something intelligent with not-yet-convert input.

(This is particularly useful in situations where partial input requires special code paths such as deciding whether to admit what the user typed as new tag or whether to discard it as incomplete data)

This becomes particularly necessary when a single page has multiple instances of react-tags, which generally make nifty hacks that rely on "what kind of DOM node did the blur fire for" are not reliable in terms of dealing with any particular's input element's hanging input.

closes #103 