### PR TITLE
Create two new options: maxInputLength and removeTagTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ React.render(<App />, document.getElementById('app'))
 - [`delimiters`](#delimiters-optional)
 - [`delimiterChars`](#delimitersChars-optional)
 - [`minQueryLength`](#minquerylength-optional)
+- [`maxInputLength`](#maxinputlength-optional)
 - [`maxSuggestionsLength`](#maxsuggestionslength-optional)
 - [`classNames`](#classnames-optional)
 - [`handleAddition`](#handleaddition-optional)
 - [`handleDelete`](#handledelete-optional)
 - [`handleInputChange`](#handleinputchange-optional)
 - [`allowNew`](#allownew-optional)
+- [`removeTagTitle`](#removetagtitle-optional)
 - [`tagComponent`](#tagcomponent-optional)
 
 #### tags (optional)
@@ -130,6 +132,10 @@ Array of characters matching keyboard event `key` values. This is useful when ne
 #### minQueryLength (optional)
 
 How many characters are needed for suggestions to appear. Default: `2`.
+
+#### maxInputLength (optional)
+
+The maxlength attribute for the input. Default: `-1` (unlimited number of characters).
 
 #### maxSuggestionsLength (optional)
 
@@ -199,6 +205,10 @@ Allows users to add new (not suggested) tags. Default: `false`.
 #### allowBackspace (optional)
 
 Disables ability to delete the selected tags when backspace is pressed while focussed on the text input. Default: `true`.
+
+#### removeTagTitle (optional)
+
+The string for the remove tag title. Default: `Click to remove tag`.
 
 #### tagComponent (optional)
 

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -71,7 +71,7 @@ class Input extends React.Component {
   render () {
     const sizerText = this.props.query || this.props.placeholder
 
-    const { expandable, placeholder, listboxId, selectedIndex } = this.props
+    const { expandable, placeholder, listboxId, selectedIndex, maxLength } = this.props
 
     const selectedId = `${listboxId}-${selectedIndex}`
 
@@ -86,6 +86,7 @@ class Input extends React.Component {
           aria-activedescendant={selectedIndex > -1 ? selectedId : null}
           aria-expanded={expandable}
           placeholder={placeholder}
+          maxLength={maxLength}
           style={{ width: this.state.inputWidth }} />
         <div ref={(c) => { this.sizer = c }} style={SIZER_STYLES}>{sizerText}</div>
       </div>

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -147,6 +147,7 @@ class ReactTags extends React.Component {
       <TagComponent
         key={i}
         tag={tag}
+        removeTagTitle={this.props.removeTagTitle}
         classNames={this.state.classNames}
         onDelete={this.deleteTag.bind(this, i)} />
     ))
@@ -173,7 +174,8 @@ class ReactTags extends React.Component {
             autofocus={this.props.autofocus}
             autoresize={this.props.autoresize}
             expandable={expandable}
-            placeholder={this.props.placeholder} />
+            placeholder={this.props.placeholder}
+            maxLength={this.props.maxInputLength} />
           <Suggestions {...this.state}
             ref={(c) => { this.suggestions = c }}
             listboxId={listboxId}
@@ -199,7 +201,9 @@ ReactTags.defaultProps = {
   maxSuggestionsLength: 6,
   allowNew: false,
   allowBackspace: true,
-  tagComponent: null
+  tagComponent: null,
+  maxInputLength: -1,
+  removeTagTitle: 'Click to remove tag'
 }
 
 ReactTags.propTypes = {
@@ -218,6 +222,8 @@ ReactTags.propTypes = {
   classNames: PropTypes.object,
   allowNew: PropTypes.bool,
   allowBackspace: PropTypes.bool,
+  maxInputLength: PropTypes.number,
+  removeTagTitle: PropTypes.string,
   tagComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.element

--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -3,7 +3,7 @@
 const React = require('react')
 
 module.exports = (props) => (
-  <button type='button' className={props.classNames.selectedTag} title='Click to remove tag' onClick={props.onDelete}>
+  <button type='button' className={props.classNames.selectedTag} title={props.removeTagTitle} onClick={props.onDelete}>
     <span className={props.classNames.selectedTagName}>{props.tag.name}</span>
   </button>
 )

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -123,6 +123,11 @@ describe('React Tags', () => {
       TestUtils.Simulate.blur($('input'))
       expect($('.is-focused')).toBeNull()
     })
+
+    it('assigns the given maxInputLength', () => {
+      createInstance({ maxInputLength: 5 })
+      expect($('input').getAttribute('maxlength')).toEqual('5')
+    })
   })
 
   describe('query', () => {
@@ -370,6 +375,18 @@ describe('React Tags', () => {
       })
 
       expect($$('.custom-tag').length).toEqual(2)
+    })
+
+    it('renders selected tags with custom remove tag title', () => {
+      createInstance({
+        tags: [fixture[0], fixture[1]],
+        removeTagTitle: 'Custom remove tag title'
+      })
+
+      const tags = $$('.react-tags__selected-tag')
+
+      expect(tags[0].getAttribute('title')).toEqual('Custom remove tag title')
+      expect(tags[1].getAttribute('title')).toEqual('Custom remove tag title')
     })
   })
 


### PR DESCRIPTION
In a recent project, I had to limit the tags lengths and translate the remove tag title.
I've made some workarounds but would be nice to have this options in an easy way.