### PR TITLE
Adding event handler to prevent clicking scroll bars closing suggestion drop down

### DIFF
--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -39,6 +39,11 @@ class Suggestions extends React.Component {
     e.preventDefault()
     this.props.addTag(item)
   }
+  
+  handleListMouseDown (e) {
+    // Fix for clicking scroll bars casuing the suggestions drop down to close
+    e.preventDefault();
+  }
 
   render () {
     if (!this.props.expandable || !this.state.options.length) {
@@ -72,7 +77,7 @@ class Suggestions extends React.Component {
 
     return (
       <div className={this.props.classNames.suggestions}>
-        <ul role='listbox' id={this.props.listboxId}>{options}</ul>
+        <ul role='listbox' id={this.props.listboxId} onMouseDown={this.handleListMouseDown.bind(this)}>{options}</ul>
       </div>
     )
   }


### PR DESCRIPTION
#121 

Fix for issue linked, where clicking scroll bars in the suggestion dropdown would close the dropdown