### PR TITLE
Add ability to pass down a name attribute to input

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ React.render(<App />, document.getElementById('app'))
 - [`tags`](#tags-optional)
 - [`suggestions`](#suggestions-optional)
 - [`placeholder`](#placeholder-optional)
+- [`name`](#name-optional)
 - [`autofocus`](#autofocus-optional)
 - [`autoresize`](#autoresize-optional)
 - [`delimiters`](#delimiters-optional)
@@ -112,6 +113,10 @@ const suggestions = [
 #### placeholder (optional)
 
 The placeholder string shown for the input. Default: `'Add new tag'`.
+
+#### name (optional)
+
+The name attribute is passed down to the input. It can be used to submit the tag as part of a form when JavaScript is disabled. Default: `'tag'`.
 
 #### autofocus (optional)
 

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -69,7 +69,7 @@ class Input extends React.Component {
   }
 
   render () {
-    const { query, placeholder, expandable, listboxId, selectedIndex } = this.props
+    const { query, placeholder, expandable, listboxId, selectedIndex, name } = this.props
 
     return (
       <div className={this.props.classNames.searchInput}>
@@ -83,7 +83,8 @@ class Input extends React.Component {
           aria-owns={listboxId}
           aria-activedescendant={selectedIndex > -1 ? `${listboxId}-${selectedIndex}` : null}
           aria-expanded={expandable}
-          style={{ width: this.state.inputWidth }} />
+          style={{ width: this.state.inputWidth }}
+          name={name} />
         <div ref={(c) => { this.sizer = c }} style={SIZER_STYLES}>{query || placeholder}</div>
       </div>
     )

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -181,7 +181,8 @@ class ReactTags extends React.Component {
             autofocus={this.props.autofocus}
             autoresize={this.props.autoresize}
             expandable={expandable}
-            placeholder={this.props.placeholder} />
+            placeholder={this.props.placeholder}
+            name={this.props.name} />
           <Suggestions {...this.state}
             ref={(c) => { this.suggestions = c }}
             listboxId={listboxId}
@@ -199,6 +200,7 @@ ReactTags.defaultProps = {
   tags: [],
   placeholder: 'Add new tag',
   suggestions: [],
+  name: 'tag',
   autofocus: true,
   autoresize: true,
   delimiters: [KEYS.TAB, KEYS.ENTER],
@@ -213,6 +215,7 @@ ReactTags.defaultProps = {
 ReactTags.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.object),
   placeholder: PropTypes.string,
+  name: PropTypes.string,
   suggestions: PropTypes.arrayOf(PropTypes.object),
   autofocus: PropTypes.bool,
   autoresize: PropTypes.bool,


### PR DESCRIPTION
This is super useful for apps which support noJs. This way we can fallback to using a form to submit the tag.