### PR TITLE
Introduce addOnBlur prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ React.render(<App />, document.getElementById('app'))
 - [`handleInputChange`](#handleinputchange-optional)
 - [`handleFocus`](#handlefocus-optional)
 - [`handleBlur`](#handleblur-optional)
+- [`addOnBlur`](#addonblur-optional)
 - [`allowNew`](#allownew-optional)
 - [`tagComponent`](#tagcomponent-optional)
 - [`inputAttributes`](#inputAttributes-optional)
@@ -202,6 +203,10 @@ Optional event handler when the input receives focus. Receives no arguments.
 #### handleBlur (optional)
 
 Optional event handler when focus on the input is lost. Receives no arguments.
+
+#### addOnBlur (optional)
+
+Creates a tag from the current input value when focus on the input is lost. Default: `false`.
 
 #### allowNew (optional)
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -123,6 +123,10 @@ class ReactTags extends React.Component {
     if (this.props.handleBlur) {
       this.props.handleBlur()
     }
+
+    if (this.props.addOnBlur) {
+      this.handleDelimiter()
+    }
   }
 
   handleFocus () {
@@ -215,7 +219,8 @@ ReactTags.defaultProps = {
   allowNew: false,
   allowBackspace: true,
   tagComponent: null,
-  inputAttributes: {}
+  inputAttributes: {},
+  addOnBlur: false
 }
 
 ReactTags.propTypes = {
@@ -240,7 +245,8 @@ ReactTags.propTypes = {
     PropTypes.func,
     PropTypes.element
   ]),
-  inputAttributes: PropTypes.object
+  inputAttributes: PropTypes.object,
+  addOnBlur: PropTypes.bool
 }
 
 module.exports = ReactTags

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -66,20 +66,7 @@ class ReactTags extends React.Component {
         e.preventDefault()
       }
 
-      if (query.length >= this.props.minQueryLength) {
-        // Check if the user typed in an existing suggestion.
-        const match = this.suggestions.state.options.findIndex((suggestion) => {
-          return suggestion.name.search(new RegExp(`^${query}$`, 'i')) === 0
-        })
-
-        const index = selectedIndex === -1 ? match : selectedIndex
-
-        if (index > -1) {
-          this.addTag(this.suggestions.state.options[index])
-        } else if (this.props.allowNew) {
-          this.addTag({ name: query })
-        }
-      }
+      this.handleDelimiter()
     }
 
     // when backspace key is pressed and query is blank, delete the last tag
@@ -102,6 +89,25 @@ class ReactTags extends React.Component {
       e.preventDefault()
 
       this.setState({ selectedIndex: (selectedIndex + 1) % this.suggestions.state.options.length })
+    }
+  }
+
+  handleDelimiter () {
+    const { query, selectedIndex } = this.state
+
+    if (query.length >= this.props.minQueryLength) {
+      // Check if the user typed in an existing suggestion.
+      const match = this.suggestions.state.options.findIndex((suggestion) => {
+        return suggestion.name.search(new RegExp(`^${query}$`, 'i')) === 0
+      })
+
+      const index = selectedIndex === -1 ? match : selectedIndex
+
+      if (index > -1) {
+        this.addTag(this.suggestions.state.options[index])
+      } else if (this.props.allowNew) {
+        this.addTag({ name: query })
+      }
     }
   }
 

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -182,6 +182,17 @@ describe('React Tags', () => {
 
       sinon.assert.calledThrice(props.handleAddition)
     })
+
+    it('adds tag on blur when addOnBlur is true', () => {
+      createInstance({ allowNew: true, addOnBlur: true })
+
+      type(query)
+
+      TestUtils.Simulate.blur($('input'))
+
+      sinon.assert.calledOnce(props.handleAddition)
+      sinon.assert.calledWith(props.handleAddition, { name: query })
+    })
   })
 
   describe('suggestions', () => {


### PR DESCRIPTION
This prop makes it so that a tag gets added onBlur. It wasn't possible to do using the existing handleBlur callback because while you can add the input, you can't erase the query.

This addresses https://github.com/i-like-robots/react-tags/issues/136.