### PR TITLE
Add clearOnDelete option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ React.render(<App />, document.getElementById('app'))
 - [`handleValidate`](#handlevalidate-optional)
 - [`addOnBlur`](#addonblur-optional)
 - [`allowNew`](#allownew-optional)
+- [`allowBackspace`](#allowbackspace-optional)
+- [`clearInputOnDelete`](#clearinputondelete-optional)
 - [`tagComponent`](#tagcomponent-optional)
 - [`inputAttributes`](#inputAttributes-optional)
 
@@ -226,6 +228,10 @@ Allows users to add new (not suggested) tags. Default: `false`.
 #### allowBackspace (optional)
 
 Disables ability to delete the selected tags when backspace is pressed while focussed on the text input. Default: `true`.
+
+#### clearInputOnDelete (optional)
+
+Clear input when tag is deleted. Default: `true`.
 
 #### tagComponent (optional)
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -168,7 +168,9 @@ class ReactTags extends React.Component {
 
   deleteTag (i) {
     this.props.handleDelete(i)
-    this.setState({ query: '' })
+    if (this.props.clearInputOnDelete) {
+      this.setState({ query: '' })
+    }
   }
 
   render () {
@@ -231,7 +233,8 @@ ReactTags.defaultProps = {
   allowBackspace: true,
   tagComponent: null,
   inputAttributes: {},
-  addOnBlur: false
+  addOnBlur: false,
+  clearInputOnDelete: true
 }
 
 ReactTags.propTypes = {
@@ -258,7 +261,8 @@ ReactTags.propTypes = {
     PropTypes.element
   ]),
   inputAttributes: PropTypes.object,
-  addOnBlur: PropTypes.bool
+  addOnBlur: PropTypes.bool,
+  clearInputOnDelete: PropTypes.bool
 }
 
 module.exports = ReactTags

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -203,6 +203,28 @@ describe('React Tags', () => {
       sinon.assert.calledOnce(props.handleAddition)
       sinon.assert.calledWith(props.handleAddition, { name: query })
     })
+
+    it('clears on tag delete when clearInputOnDelete is true', () => {
+      createInstance({ tags: [fixture[0], fixture[1]] })
+
+      type(query)
+
+      click($('.react-tags__selected-tag'))
+
+      const input = $('input')
+      expect(input.value).toEqual('')
+    })
+
+    it('does not clear on tag delete when clearInputOnDelete is false', () => {
+      createInstance({ tags: [fixture[0], fixture[1]], clearInputOnDelete: false })
+
+      type(query)
+
+      click($('.react-tags__selected-tag'))
+
+      const input = $('input')
+      expect(input.value).toEqual(query)
+    })
   })
 
   describe('suggestions', () => {


### PR DESCRIPTION
Hello. Thanks for the great component. 
I'm using it in my project and found it weird it clears the input when tag is deleted. Seems it would be good to have it as an option with backwards compatible default `true`.