### PR TITLE
Added query parameter to suggestionsFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,20 @@ const suggestions = [
 
 #### suggestionsFilter (optional)
 
-A function to filter suggestion items on; takes a suggestion `item` as the single argument.
+A function to filter suggestion items on; takes a `query` as the single argument and must return callback function which takes a suggestion `item` as the single argument.
 
 If no function is supplied the default filter is applied. Default: `null`.
+
+Example of a function which returns items containing `query`:
+```js
+function suggestionsFilter(query) {
+  const escapeForRegExp = (query) => {
+    return query.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
+  }
+  const regex = new RegExp(`${escapeForRegExp(query)}`, 'i')
+  return (item) => regex.test(item.name)
+}
+```
 
 #### placeholder (optional)
 

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -17,10 +17,10 @@ function markIt (input, query) {
 function filterSuggestions (query, suggestions, length, suggestionsFilter) {
   if (!suggestionsFilter) {
     const regex = new RegExp(`(?:^|\\s)${escapeForRegExp(query)}`, 'i')
-    suggestionsFilter = (item) => regex.test(item.name)
+    suggestionsFilter = () => (item) => regex.test(item.name)
   }
 
-  return suggestions.filter(suggestionsFilter).slice(0, length)
+  return suggestions.filter(suggestionsFilter(query)).slice(0, length)
 }
 
 class Suggestions extends React.Component {


### PR DESCRIPTION
suggestionsFilter can now accept `query` argument and must return callback function which accepts suggestion `item` as a single argument.

Also updated instructions in README