### PR TITLE
Fixes #171

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -57,6 +57,10 @@ class ReactTags extends React.Component {
     })
   }
 
+  resetSelectedIndex () {
+    this.setState({ selectedIndex: -1 })
+  }
+
   handleInput (e) {
     const query = e.target.value
 
@@ -213,6 +217,7 @@ class ReactTags extends React.Component {
             expandable={expandable}
             suggestions={this.props.suggestions}
             suggestionsFilter={this.props.suggestionsFilter}
+            resetSelectedIndex={this.resetSelectedIndex.bind(this)}
             addTag={this.addTag.bind(this)}
             maxSuggestionsLength={this.props.maxSuggestionsLength} />
         </div>

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -36,9 +36,14 @@ class Suggestions extends React.Component {
   }
 
   componentWillReceiveProps (newProps) {
-    this.setState({
-      options: filterSuggestions(newProps.query, newProps.suggestions, newProps.maxSuggestionsLength, newProps.suggestionsFilter)
-    })
+    const options = filterSuggestions(newProps.query, newProps.suggestions, newProps.maxSuggestionsLength, newProps.suggestionsFilter)
+
+    // If the index is out of bounds, reset it
+    if (this.props.selectedIndex > options.length - 1) {
+      this.props.resetSelectedIndex()
+    }
+
+    this.setState({ options })
   }
 
   handleMouseDown (item, e) {


### PR DESCRIPTION
Added `resetSelectedIndex` to the Suggestions component. It resets `selectedIndex` state when suggestions are filtered and the index is out of bounds.