### PR TITLE
Allow custom filter for suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const suggestions = [
 
 A callback function to filter suggestion items with. The callback receives two arguments; a `suggestion` and the current `query` and must return a boolean value.
 
-If no function is supplied the default filter is applied. Defaults to `null`. 
+If no function is supplied the default filter is applied. Defaults to `null`.
 
 **Note:** This filter will be ignored if [suggestionsTransform](#suggestionsTransform-optional) is supplied.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const suggestions = [
 
 #### suggestionsFilter (optional)
 
-A callback function to filter suggestions. The callback receives two arguments; a `query` and the input `suggestions` and must return a list of filtered suggestion.
+A callback function to filter suggestions. The callback receives two arguments; a `query` and the input [suggestions](#suggestions-optional) and must return a list of filtered suggestion.
 
 If no function is supplied the default filter is applied. Defaults to `null`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a [Node.js] module available through the [npm] registry. Before installi
 Installation is done using the [npm install] command:
 
 ```
-npm install --save react-tag-autocomplete@pre-release
+npm install --save react-tag-autocomplete
 ```
 
 [Node.js]: https://nodejs.org/en/
@@ -133,9 +133,17 @@ const suggestions = [
 
 #### suggestionsFilter (optional)
 
-A callback function to filter suggestion items with. The callback receives two arguments; a `suggestion` and the current `query` and must return a boolean value.
+A callback function to filter suggestions. The callback receives two arguments; a `query` and the input `suggestions` and must return a list of filtered suggestion.
 
 If no function is supplied the default filter is applied. Defaults to `null`.
+
+```js
+import matchSorter from "match-sorter";
+
+function suggestionsFilter(query, suggestions) {
+  return matchSorter(suggestions, query, { keys: ["name"] });
+}
+```
 
 #### placeholderText (optional)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ReactDOM.render(<App />, document.getElementById('app'))
 - [`tags`](#tags-optional)
 - [`suggestions`](#suggestions-optional)
 - [`suggestionsFilter`](#suggestionsfilter-optional)
+- [`suggestionsTransform`](#suggestionsTransform-optional)
 - [`placeholderText`](#placeholdertext-optional)
 - [`ariaLabelText`](#arialabeltext-optional)
 - [`removeButtonText`](#removeButtontext-optional)
@@ -133,9 +134,15 @@ const suggestions = [
 
 #### suggestionsFilter (optional)
 
-A callback function to filter suggestions. The callback receives two arguments; a `query` and the input [suggestions](#suggestions-optional) and must return a list of filtered suggestion.
+A callback function to filter suggestion items with. The callback receives two arguments; a `suggestion` and the current `query` and must return a boolean value.
 
-If no function is supplied the default filter is applied. Defaults to `null`.
+If no function is supplied the default filter is applied. Defaults to `null`. 
+
+**Note:** This filter will be ignored if [suggestionsTransform](#suggestionsTransform-optional) is supplied.
+
+#### suggestionsTransform (optional)
+
+A callback function to apply custom filter to the suggestions. The callback receives two arguments; a `query` and the input [suggestions](#suggestions-optional) and must return a list of filtered suggestion. This will supersede [suggestionsFilter](#suggestionsfilter-optional)
 
 ```js
 import matchSorter from "match-sorter";

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -69,13 +69,13 @@ function pressBackspaceKey () {
   }
 }
 
-function defaultSuggestionsFilter (item, query) {
+function defaultSuggestionsFilter (query, suggestions) {
   const regexp = matchPartial(query)
-  return regexp.test(item.name)
+  return suggestions.filter(item => regexp.test(item.name))
 }
 
 function getOptions (props, state) {
-  const options = props.suggestions.filter((item) => props.suggestionsFilter(item, state.query))
+  const options = props.suggestionsFilter(state.query, props.suggestions)
 
   if (options.length === 0 && props.noSuggestionsText) {
     options.push({ id: 0, name: props.noSuggestionsText, disabled: true, disableMarkIt: true })

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -69,13 +69,18 @@ function pressBackspaceKey () {
   }
 }
 
-function defaultSuggestionsFilter (query, suggestions) {
+function defaultSuggestionsFilter (item, query) {
   const regexp = matchPartial(query)
-  return suggestions.filter(item => regexp.test(item.name))
+  return regexp.test(item.name)
 }
 
 function getOptions (props, state) {
-  const options = props.suggestionsFilter(state.query, props.suggestions)
+  let options
+  if (props.suggestionsTransform) {
+    options = props.suggestionsTransform(state.query, props.suggestions)
+  } else {
+    options = props.suggestions.filter((item) => props.suggestionsFilter(item, state.query))
+  }
 
   if (options.length === 0 && props.noSuggestionsText) {
     options.push({ id: 0, name: props.noSuggestionsText, disabled: true, disableMarkIt: true })
@@ -299,6 +304,7 @@ ReactTags.defaultProps = {
   noSuggestionsText: null,
   suggestions: [],
   suggestionsFilter: defaultSuggestionsFilter,
+  suggestionsTransform: null,
   autoresize: true,
   classNames: CLASS_NAMES,
   delimiters: [KEYS.TAB, KEYS.ENTER],
@@ -321,6 +327,7 @@ ReactTags.propTypes = {
   noSuggestionsText: PropTypes.string,
   suggestions: PropTypes.arrayOf(PropTypes.object),
   suggestionsFilter: PropTypes.func,
+  suggestionsTransform: PropTypes.func,
   autoresize: PropTypes.bool,
   delimiters: PropTypes.arrayOf(PropTypes.string),
   onDelete: PropTypes.func.isRequired,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "coveralls": "^3.0.0",
     "jasmine": "^3.5.0",
     "jsdom": "^16.1.0",
+    "match-sorter": "^4.1.0",
     "nyc": "^15.0.0",
     "prop-types": "^15.7.0",
     "react": "^16.10.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "coveralls": "^3.0.0",
     "jasmine": "^3.5.0",
     "jsdom": "^16.1.0",
-    "match-sorter": "^4.1.0",
+    "match-sorter": "^4.2.0",
     "nyc": "^15.0.0",
     "prop-types": "^15.7.0",
     "react": "^16.10.0",

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -6,6 +6,8 @@ const React = require('react')
 const ReactDOM = require('react-dom')
 const TestUtils = require('react-dom/test-utils')
 const sinon = require('sinon')
+const matchSorter = require('match-sorter').default
+
 const fixture = require('../example/countries')
 const Subject = require('../')
 
@@ -255,11 +257,25 @@ describe('React Tags', () => {
       })
     })
 
+    it('uses default suggestionsFilter', () => {
+      createInstance({
+        minQueryLength: 3,
+        suggestions: fixture
+      })
+
+      type('Indi')
+
+      const results = $$('li[role="option"]')
+
+      expect(results.some((result) => result.textContent === 'India')).toBeTruthy()
+      expect(results.some((result) => result.textContent === 'Indonesia')).toBeFalsy()
+    })
+
     it('uses provided suggestionsFilter callback', () => {
       createInstance({
         minQueryLength: 3,
         suggestions: fixture,
-        suggestionsFilter: (item, query) => item.name.includes(query)
+        suggestionsFilter: (query, suggestions) => matchSorter(suggestions, query, { keys: ['name'] })
       })
 
       type('uni')
@@ -268,6 +284,7 @@ describe('React Tags', () => {
 
       expect(results.some((result) => result.textContent === 'Reunion')).toBeTruthy()
       expect(results.some((result) => result.textContent === 'Tunisia')).toBeTruthy()
+      expect(results.some((result) => result.textContent === 'United Kingdom')).toBeTruthy()
     })
 
     it('can handle non-ascii characters', () => {

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -276,7 +276,40 @@ describe('React Tags', () => {
       createInstance({
         minQueryLength: 3,
         suggestions: fixture,
-        suggestionsFilter: (query, suggestions) => matchSorter(suggestions, query, { keys: ['name'] })
+        suggestionsFilter: (item, query) => item.name.includes(query)
+      })
+
+      type('uni')
+
+      const results = $$('li[role="option"]')
+
+      expect(results.some((result) => result.textContent === 'Reunion')).toBeTruthy()
+      expect(results.some((result) => result.textContent === 'Tunisia')).toBeTruthy()
+    })
+
+    it('should ignore suggestionsFilter when suggestionsTransform is provided', () => {
+      const suggestionsFilter = jasmine.createSpy('suggestionsFilter').and.callFake((item, query) => item.name.includes(query))
+
+      createInstance({
+        minQueryLength: 3,
+        suggestions: fixture,
+        suggestionsFilter,
+        suggestionsTransform: (query, suggestions) => matchSorter(suggestions, query, { keys: ['name'] })
+      })
+
+      type('uni')
+
+      const results = $$('li[role="option"]')
+
+      expect(results[0].textContent).toBe('United Arab Emirates') // best matches
+      expect(suggestionsFilter).not.toHaveBeenCalled()
+    })
+
+    it('uses provided suggestionsTransform callback', () => {
+      createInstance({
+        minQueryLength: 3,
+        suggestions: fixture,
+        suggestionsTransform: (query, suggestions) => matchSorter(suggestions, query, { keys: ['name'] })
       })
 
       type('uni')

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -267,6 +267,7 @@ describe('React Tags', () => {
 
       const results = $$('li[role="option"]')
 
+      expect(results.some((result) => result.textContent === 'French West Indies')).toBeTruthy()
       expect(results.some((result) => result.textContent === 'India')).toBeTruthy()
       expect(results.some((result) => result.textContent === 'Indonesia')).toBeFalsy()
     })
@@ -282,9 +283,10 @@ describe('React Tags', () => {
 
       const results = $$('li[role="option"]')
 
+      expect(results[0].textContent).toBe('United Arab Emirates') // best matches
+      expect(results[1].textContent).toBe('United Kingdom') // best matches
       expect(results.some((result) => result.textContent === 'Reunion')).toBeTruthy()
       expect(results.some((result) => result.textContent === 'Tunisia')).toBeTruthy()
-      expect(results.some((result) => result.textContent === 'United Kingdom')).toBeTruthy()
     })
 
     it('can handle non-ascii characters', () => {


### PR DESCRIPTION
Sometimes we might require more than just plain filter, like sort based on best match and etc. 

This is a breaking change. I tried to introduce a new prop or something to avoid it, but that would just create confusion by having multiple filters.