### PR TITLE
Make "npm run dev" work also on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "optionalDependencies": {
+    "win-node-env": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "standard lib/*.js spec/*.js",
     "test": "jasmine",
     "coverage": "nyc --include 'dist/**' npm test",
-    "dev": "NODE_ENV=development rollup -c example/rollup.config.js --watch",
-    "example": "NODE_ENV=production rollup -c example/rollup.config.js",
+    "dev": "rollup --environment=NODE_ENV:development -c example/rollup.config.js --watch",
+    "example": "rollup --environment=NODE_ENV:production -c example/rollup.config.js",
     "build": "rollup -c rollup.config.js"
   },
   "keywords": [
@@ -66,8 +66,5 @@
   },
   "engines": {
     "node": ">= 10.0.0"
-  },
-  "optionalDependencies": {
-    "win-node-env": "^0.4.0"
   }
 }


### PR DESCRIPTION
It's impossible to launch the `npm run dev` on Windows as the following command fails:

```bash
NODE_ENV=development rollup -c example/rollup.config.js --watch
```

We integrated the [win-node-env](https://www.npmjs.com/package/win-node-env) to work around this problem. As a result the `npm run dev` is now cross-platform.