### PR TITLE
Fixed resizing issue on placeholder changes

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -34,8 +34,8 @@ class Input extends React.Component {
     }
   }
 
-  componentDidUpdate ({ query, placeholder }) {
-    if (query !== this.props.query || placeholder !== this.props.placeholder) {
+  componentDidUpdate ({ query, placeholderText }) {
+    if (query !== this.props.query || placeholderText !== this.props.placeholderText) {
       this.updateInputWidth()
     }
   }


### PR DESCRIPTION
Currently the input does not resize, when the placeholder changes.

### Use case
We're using it, to have a different placeholder when there are no tags vs. already tags added.

This is the initial state:
![Screenshot 2021-03-19 at 12 53 53](https://user-images.githubusercontent.com/1721016/111776368-37673900-88b2-11eb-8b63-c376d67d0a31.png)

This is after a tag has been added:
![Screenshot 2021-03-19 at 12 54 04](https://user-images.githubusercontent.com/1721016/111776374-3930fc80-88b2-11eb-83e5-e09719f9520a.png)

### Code to reproduce the error:
```
<ReactTags
  {...props}
  placeholderText={
    props.tags?.length !== 0 ? 'Add new tag' : 'Add new tag (e.g. Cost Center, Departement, Team, Status)'
  }
/>
```

### Fix within this PR:
- [x] adapted to the new prop name `placeholderText` instead of `placeholder`