### PR TITLE
Add optional prop to entirelly disable text input

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ReactDOM.render(<App />, document.getElementById('app'))
 - [`onValidate`](#onvalidate-optional)
 - [`addOnBlur`](#addonblur-optional)
 - [`allowNew`](#allownew-optional)
+- [`inputDisabled`](#inputdisabled-optional)
 - [`allowBackspace`](#allowbackspace-optional)
 - [`tagComponent`](#tagcomponent-optional)
 - [`suggestionComponent`](#suggestioncomponent-optional)
@@ -277,6 +278,10 @@ Creates a tag from the current input value when focus on the input is lost. Defa
 #### allowNew (optional)
 
 Enable users to add new (not suggested) tags. Defaults to `false`.
+
+#### inputDisabled (optional)
+
+Disables input field. Defaults to `false`.
 
 #### allowBackspace (optional)
 

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -63,7 +63,7 @@ class Input extends React.Component {
   }
 
   render () {
-    const { id, query, ariaLabelText, placeholderText, expanded, classNames, inputAttributes, inputEventHandlers, index } = this.props
+    const { id, query, ariaLabelText, placeholderText, expanded, classNames, inputAttributes, inputDisabled, inputEventHandlers, index } = this.props
 
     return (
       <div className={classNames.searchWrapper}>
@@ -81,6 +81,7 @@ class Input extends React.Component {
           aria-activedescendant={index > -1 ? `${id}-${index}` : null}
           aria-expanded={expanded}
           style={{ width: this.state.inputWidth }}
+          disabled={inputDisabled}
         />
         <div ref={this.sizer} style={SIZER_STYLES}>{query || placeholderText}</div>
       </div>

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -282,6 +282,7 @@ class ReactTags extends React.Component {
             expanded={expanded}
             placeholderText={this.props.placeholderText}
             ariaLabelText={this.props.ariaLabelText}
+            inputDisabled={this.props.inputDisabled}
           />
           <Suggestions
             {...this.state}
@@ -326,6 +327,7 @@ ReactTags.defaultProps = {
   minQueryLength: 2,
   maxSuggestionsLength: 6,
   allowNew: false,
+  inputDisabled: false,
   allowBackspace: true,
   addOnBlur: false,
   tagComponent: null,
@@ -356,6 +358,7 @@ ReactTags.propTypes = {
   maxSuggestionsLength: PropTypes.number,
   classNames: PropTypes.object,
   allowNew: PropTypes.bool,
+  inputDisabled: PropTypes.bool,
   allowBackspace: PropTypes.bool,
   addOnBlur: PropTypes.bool,
   tagComponent: PropTypes.oneOfType([


### PR DESCRIPTION
This addition was useful for my team. 

We had another component that we created that would add and remove tags on react-tags. We did not want the user to be able to type any tags into the input field, they needed to use the other component to add or remove tags from react-tags.

This PR adds an optional flag to entirely disable the input box in react-tags. Opening the PR in case it is useful to others.