### PR TITLE
Allow React 17 as peer dependency (Fixes #236)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "repository": "https://github.com/i-like-robots/react-tags",
   "peerDependencies": {
     "prop-types": "^15.5.0",
-    "react": "^16.5.0",
-    "react-dom": "^16.5.0"
+    "react": "^16.5.0 || ^17.0.0",
+    "react-dom": "^16.5.0 || ^17.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.0",


### PR DESCRIPTION
This resolves #236 and any warnings. So far, React 17 didn't give any issues with this plugin.