### PR TITLE
Add clearSuggestionSelection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,11 @@ Removes a tag from the list of selected tags. This will trigger the delete callb
 
 #### `clearInput()`
 
-Clears the input and current query.
+Clears the input, current query and suggestion selection.
+
+#### `clearSuggestionSelection()`
+
+Clears the suggestion selection.
 
 #### `focusInput()`
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -233,6 +233,10 @@ class ReactTags extends React.Component {
     })
   }
 
+  clearSuggestionSelection () {
+    this.setState({ index: -1 })
+  }
+
   focusInput () {
     if (this.input.current && this.input.current.input.current) {
       this.input.current.input.current.focus()

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -425,7 +425,7 @@ describe('React Tags', () => {
     })
 
     it('does not trigger addition for a previously selected suggestion when no longer suggested', () => {
-      type('french'); key('down', 'down'); type('fries'); key('enter')
+      type('french'); key('ArrowDown', 'ArrowDown'); type('fries'); key('Enter')
 
       sinon.assert.notCalled(props.onAddition)
     })

--- a/spec/ReactTags.spec.js
+++ b/spec/ReactTags.spec.js
@@ -508,6 +508,17 @@ describe('React Tags', () => {
         expect($$('li[role="option"]').length).toEqual(6)
       })
     })
+
+    it('suggestion selection can be cleared programmatically', () => {
+      type('french')
+      key('ArrowDown', 'ArrowDown')
+
+      expect(instance.state.index).toBe(1)
+
+      instance.clearSuggestionSelection()
+
+      expect(instance.state.index).toBe(-1)
+    })
   })
 
   describe('tags', () => {


### PR DESCRIPTION
I'm proposing clearSuggestionSelection method to be added. This allows the developer to reset ReactTag's inner `index` state back to the initial value of `-1`. Resetting `index` has the effect of clearing the current suggestion selection.

# Use case
Suggestions list is populated with most recent tags. Suggestion list is not filtered according the user input. Whatever the user types into the input field the suggestion list stays the same. User can select a suggested tag from the suggestion list or they can write a completely new tag.

# Scenario where current behaviour is problematic
1. User types something into the input field.
2. Suggestion list is presented.
3. User uses arrow keys to select a suggestion.
4. But instead of adding the selected suggestion the user writes a custom tag.
5. User presses the delimiter key in order to add the custom tag they wrote.
Problem: ReactTags adds the tag that was selected earlier, not the one user had written into the input field.

See the GIF below for a visual demonstration. In it the user wants to add tag ‘hello’. Instead the previously selected tag ‘jäte’ is added.

![suggestion-selection-not-cleared-after-typing-more](https://user-images.githubusercontent.com/2562206/130917175-2ffc4b99-24a5-4758-9f79-d9b34aecafd6.gif)

# How clearSuggestionSelection fixes the problem
By calling `clearSuggestionSelection` in `onInput` callback function the problem is solved. See the GIF below for a demonstration. In it the user is able to add tag ‘hello’ even though they selected tag ‘jäte’ previously.

![suggestion-selection-cleared-after-typing-more](https://user-images.githubusercontent.com/2562206/130917735-435aa4e1-429a-4c59-a0c7-0f6ffd6da3d6.gif)